### PR TITLE
use nopassword sudo in local development using vagrant

### DIFF
--- a/nodes/local.prepan.org.json
+++ b/nodes/local.prepan.org.json
@@ -16,7 +16,8 @@
 
     "authorization":  {
         "sudo": {
-            "users": ["vagrant", "deployer"]
+            "users": ["vagrant", "deployer"],
+            "passwordless": "true"
         }
     }
 }


### PR DESCRIPTION
use nopassword sudo for vagrant, because we cannot `halt` VM if need to input
password
